### PR TITLE
Improve UX by only showing hour if not zero

### DIFF
--- a/src/app/components/yannbf/timer-progress/timer-progress.component.ts
+++ b/src/app/components/yannbf/timer-progress/timer-progress.component.ts
@@ -96,10 +96,12 @@ export class TimerProgressComponent implements OnInit {
     let hoursString = '';
     let minutesString = '';
     let secondsString = '';
-    hoursString = (hours < 10) ? '0' + hours : hours.toString();
+    if (hours > 0) {
+        hoursString = (hours < 10) ? '0' + hours + ':' : hours.toString() + ':';
+    }
     minutesString = (minutes < 10) ? '0' + minutes : minutes.toString();
     secondsString = (seconds < 10) ? '0' + seconds : seconds.toString();
-    return hoursString + ':' + minutesString + ':' + secondsString;
+    return hoursString + minutesString + ':' + secondsString;
   }
 
 }


### PR DESCRIPTION
In a lot of cases the hour will be 0 and it improves the user experience to only display the hour if it is not zero.